### PR TITLE
Fix CSS focus selector

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@
   box-sizing: border-box;
 }
 
-*:fucus{
+*:focus{
   outline: none;
 }
 


### PR DESCRIPTION
## Summary
- correct CSS focus selector

## Testing
- `npm test --silent -- --watchAll=false` *(fails: FirebaseError projectId must be a string)*

------
https://chatgpt.com/codex/tasks/task_e_685d5ed892f08326a927f172999820bc