### PR TITLE
Fix SPA routing for shared links

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { HashRouter as Router, Route, Switch } from "react-router-dom";
 
 import { Menu } from "./components/menu/menu";
 import Footer from "./components/footer/Footer";
@@ -27,7 +27,7 @@ import ScrollToTop from "./components/scrollToTop/ScrollToTop";
 const App = () => {
   return (
     <div className="App">
-      <Router>
+      <Router basename={process.env.PUBLIC_URL}>
         {/* menu spacer for the responsive menu */}
         <div className="menu-spacer" />
         <Menu />

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,4 +1,4 @@
-const prefix = "/AguaZarca"
+const prefix = ""
 
 export const HOME = prefix + "/"
 export const VENTA = prefix + "/venta"


### PR DESCRIPTION
## Summary
- use `HashRouter` so deep links don't trigger 404s on GitHub Pages
- adjust routes to work without a prefix

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68601fabed688326ad734c9df11267ae