### PR TITLE
Add Firebase pagination to admin dashboard

### DIFF
--- a/src/components/routes/dashboard/dashboard.css
+++ b/src/components/routes/dashboard/dashboard.css
@@ -47,3 +47,10 @@
 .db-blog-create-link a{
     color: #0000ee;
 }
+
+.db-load-more{
+    margin: 20px auto;
+    padding: 10px 20px;
+    cursor: pointer;
+    display: block;
+}


### PR DESCRIPTION
## Summary
- implement paging in the admin dashboard to load properties in batches
- add 'Cargar más' button and styles

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602b29943c83268c694879b313d8df