### PR TITLE
Improve publish page when not logged in

### DIFF
--- a/src/components/routes/publicar/Publicar.js
+++ b/src/components/routes/publicar/Publicar.js
@@ -11,8 +11,9 @@ import "./publicar.css";
 import * as CF from "./const_funct"; //all the constants and functions, the component started to be a little bit too load
 import { auth, firestore } from "../../../firebase";
 import { reducer } from "./reducer";
-import { Redirect } from "react-router-dom";
-import { PROPIEDAD } from "../../../routes";
+import { Redirect, Link } from "react-router-dom";
+import LogInForm from "../../logInform/LogInForm";
+import { PROPIEDAD, CONTACTO } from "../../../routes";
 /*
  *************************** Component ******************************
  */
@@ -368,11 +369,17 @@ export const Publicar = () => {
           </form>
         </div>
       ) : (
-        <div>
+        <div className="publish-not-logged">
           {false && <Redirect to={PROPIEDAD + redirect} />}
           <p className="publish-sorry-not-alowed">
-            Tienes que ingresar en una cuenta para podes publicar una propiedad
+            Tienes que ingresar en una cuenta para poder publicar una propiedad
           </p>
+          <div className="publish-login-wrapper">
+            <LogInForm />
+            <p className="publish-contact-text">
+              ¿No tienes cuenta? <Link to={CONTACTO}>Contáctanos para publicar</Link>
+            </p>
+          </div>
         </div>
       )}
     </div>

--- a/src/components/routes/publicar/publicar.css
+++ b/src/components/routes/publicar/publicar.css
@@ -295,5 +295,26 @@ input[type=checkbox]{
     margin: 10px;
     padding: 10px;
   }
-  
+
+}
+
+.publish-not-logged {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 10px;
+}
+
+.publish-login-wrapper .log-div {
+  position: static;
+}
+
+.publish-contact-text {
+  margin-top: 10px;
+}
+
+.publish-sorry-not-alowed {
+  font-size: 18px;
+  color: rgb(71, 71, 71);
+  margin-bottom: 20px;
 }


### PR DESCRIPTION
## Summary
- clean up not-logged-in view
- use contact link instead of registration

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686031e3eccc83269607a7f57d85237f