### PR TITLE
Improve property creation form

### DIFF
--- a/src/components/routes/publicar/Publicar.js
+++ b/src/components/routes/publicar/Publicar.js
@@ -117,26 +117,33 @@ export const Publicar = () => {
         <div className="publish-form">
           <ToastContainer />
           <div className="publish-form-mercadolibre">
-            <label htmlFor="autofill"> AutoFill con Mercado libre </label>
             <input
+              id="autofill"
               className="publish-form-mercadolibre-in"
               type="checkbox"
-              value={autofill}
+              checked={autofill}
               onChange={(e) => setAutofill(e.target.checked)}
               name="autofill"
             />
-            {autofill && (
-              <div>
-                <input
-                  className="publish-form-mercadolibre-url"
-                  type="text"
-                  value={input}
-                  onChange={(e) => setInput(e.target.value)}
-                  name="mlurl"
-                />
-              </div>
-            )}
+            <label htmlFor="autofill" className="publish-form-mercadolibre-label">
+              Autocompletar con MercadoLibre
+            </label>
           </div>
+          {autofill && (
+            <div className="publish-form-mercadolibre-url-div">
+              <input
+                className="publish-form-mercadolibre-url"
+                type="text"
+                placeholder="Pega aquí la URL de la publicación de MercadoLibre"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                name="mlurl"
+              />
+              <small className="publish-form-mercadolibre-help">
+                Se completarán automáticamente los datos si la URL es válida
+              </small>
+            </div>
+          )}
           <form encType="multipart/form-data" className="publish-form-form">
             <div className="publish-form-title-price-div">
               <label className="publish-form-title-label" htmlFor="title">

--- a/src/components/routes/publicar/publicar.css
+++ b/src/components/routes/publicar/publicar.css
@@ -10,23 +10,41 @@
     color: rgb(71, 71, 71);
 }
 
-.publish-form-mercadolibre{
+.publish-form-mercadolibre {
   display: flex;
-  justify-content: flex-end;
-  margin: 10px 0;
-  padding: 10px 0;
+  align-items: center;
+  background-color: #fafafa;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  padding: 10px;
+  margin-bottom: 20px;
 }
 
-.publish-form-mercadolibre-in{
-  margin: 5px 4px 0;
+.publish-form-mercadolibre-in {
+  margin-right: 8px;
 }
 
-.publish-form-mercadolibre-url{
-  margin-left: 4px;
-  margin-top: -3px;
-  padding: 4px;
+.publish-form-mercadolibre-label {
+  flex: 1 1 auto;
+  font-weight: 500;
+}
+
+.publish-form-mercadolibre-url-div {
+  margin-top: 10px;
+}
+
+.publish-form-mercadolibre-url {
+  width: 100%;
+  padding: 8px;
+  margin-top: 4px;
   color: rgb(95, 95, 95);
+}
 
+.publish-form-mercadolibre-help {
+  display: block;
+  font-size: 12px;
+  color: rgb(120, 120, 120);
+  margin-top: 4px;
 }
 
 .publish-form-input{


### PR DESCRIPTION
## Summary
- refine MercadoLibre autofill section of the form
- enhance styles for the MercadoLibre area

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68604220c390832682bf3718ee2326fb