### PR TITLE
Add available dates calendar to property form

### DIFF
--- a/src/components/Slider/AvailableDatesSlider.js
+++ b/src/components/Slider/AvailableDatesSlider.js
@@ -1,0 +1,30 @@
+import React from "react";
+import SliderProvider from "react-slick";
+import "slick-carousel/slick/slick.css";
+import "slick-carousel/slick/slick-theme.css";
+import "./slider.css";
+
+const settings = {
+  dots: true,
+  infinite: false,
+  speed: 500,
+  slidesToShow: 3,
+  slidesToScroll: 1,
+  className: "slides",
+  centerPadding: "0px",
+};
+
+const AvailableDatesSlider = ({ dates = [] }) => {
+  if (!dates.length) return null;
+  return (
+    <SliderProvider className="slider-main" {...settings}>
+      {dates.map((d) => (
+        <div key={d} className="dates-slide">
+          {new Date(d).toLocaleDateString()}
+        </div>
+      ))}
+    </SliderProvider>
+  );
+};
+
+export default AvailableDatesSlider;

--- a/src/components/Slider/slider.css
+++ b/src/components/Slider/slider.css
@@ -197,3 +197,14 @@
     padding-right: 80px;
   }
 }
+
+.dates-slide {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 80px;
+  background-color: #fafafa;
+  border: 1px solid #e0e0e0;
+  margin: 10px;
+  font-size: 16px;
+}

--- a/src/components/routes/propiedad/Propiedad.js
+++ b/src/components/routes/propiedad/Propiedad.js
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import { firestore } from "../../../firebase";
 import mapboxgl from "mapbox-gl";
 import ProductSlider from "../../Slider/ProductSlider";
+import AvailableDatesSlider from "../../Slider/AvailableDatesSlider";
 import "./propiedad.css";
 import { icons } from "../../Slider/Slider";
 import { IconContext } from "react-icons";
@@ -62,6 +63,12 @@ const InmuebleBody = (props) => {
       <div className="inm-slider">
         <ProductSlider images={images} />
       </div>
+      {comercialStatus === "Alquiler temporal" && props.document.availableDates && (
+        <div className="inm-dates-slider">
+          <h2 className="inm-dates-title">Fechas disponibles</h2>
+          <AvailableDatesSlider dates={props.document.availableDates} />
+        </div>
+      )}
       <div className="inm-placement">
         <div className="inm-body">
           <div className="inm-body-char">

--- a/src/components/routes/propiedad/propiedad.css
+++ b/src/components/routes/propiedad/propiedad.css
@@ -189,6 +189,10 @@
     margin: 0;
   }
 
+  .inm-dates-slider {
+    margin: 20px 0;
+  }
+
   .inm-placement {
     flex-direction: column;
     margin: 10px;
@@ -256,6 +260,9 @@
     margin-right: 30px;
     margin-left: 30px;
   }
+  .inm-dates-slider {
+    margin: 20px 30px;
+  }
   .inm-placement {
     flex-direction: column;
   }
@@ -312,4 +319,13 @@
   to {
     transform: rotate(1turn);
   }
+}
+
+.inm-dates-slider {
+  margin: 20px 100px;
+}
+
+.inm-dates-title {
+  font-weight: 400;
+  margin-bottom: 10px;
 }

--- a/src/components/routes/publicar/Publicar.js
+++ b/src/components/routes/publicar/Publicar.js
@@ -27,6 +27,7 @@ export const Publicar = () => {
   const [state, dispatch] = useReducer(reducer, CF.initialState);
   const [redirect, setRedirect] = useState("");
   const [switchImage, setSwitchImage] = useState(0);
+  const [newDate, setNewDate] = useState("");
 
   const { acceptedFiles, getRootProps, getInputProps } = useDropzone();
 
@@ -249,7 +250,7 @@ export const Publicar = () => {
                     }
                   />
                 </div>
-              ))}
+              ))
             </div>
             <div className="publish-form-char">
               <h2 className="publish-candf-title"> Características y atributos</h2>
@@ -341,6 +342,38 @@ export const Publicar = () => {
                   title="video"
                 />
               )}
+            </div>
+            <div className="publish-form-dates">
+              <h2 className="publish-candf-title">Fechas Disponibles</h2>
+              <div className="publish-form-dates-input">
+                <input
+                  type="date"
+                  value={newDate}
+                  onChange={(e) => setNewDate(e.target.value)}
+                />
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (newDate)
+                      dispatch({ type: "addDate", value: newDate });
+                  }}
+                >
+                  Agregar
+                </button>
+              </div>
+              <ul className="publish-form-dates-list">
+                {state.availableDates.map((d) => (
+                  <li key={d} className="publish-form-dates-item">
+                    {d}
+                    <button
+                      type="button"
+                      onClick={() => dispatch({ type: "removeDate", value: d })}
+                    >
+                      x
+                    </button>
+                  </li>
+                ))}
+              </ul>
             </div>
             <div>
               <input

--- a/src/components/routes/publicar/const_funct.js
+++ b/src/components/routes/publicar/const_funct.js
@@ -97,6 +97,7 @@ export const initialState = {
     country: "Argentina",
   },
   video_id: "",
+  availableDates: [],
 };
 
 export const dropdownVariables = {

--- a/src/components/routes/publicar/publicar.css
+++ b/src/components/routes/publicar/publicar.css
@@ -336,3 +336,24 @@ input[type=checkbox]{
   color: rgb(71, 71, 71);
   margin-bottom: 20px;
 }
+
+.publish-form-dates {
+  margin-top: 20px;
+}
+
+.publish-form-dates-input {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.publish-form-dates-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.publish-form-dates-item {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}

--- a/src/components/routes/publicar/reducer.js
+++ b/src/components/routes/publicar/reducer.js
@@ -44,6 +44,17 @@ export const reducer = (state, action) => {
       };
     case "fullfilWithML":
       return {...state, ...action.value};
+    case "addDate":
+      if (state.availableDates.includes(action.value)) return state;
+      return {
+        ...state,
+        availableDates: [...state.availableDates, action.value],
+      };
+    case "removeDate":
+      return {
+        ...state,
+        availableDates: state.availableDates.filter((d) => d !== action.value),
+      };
 
     default:
       return state;


### PR DESCRIPTION
## Summary
- allow property listings to include available dates
- support adding/removing dates in publication form
- store available dates in Firestore
- style available dates section
- show available dates slider on temporary rental property pages

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604a6cf0648326aa1e386ca0d72038