### PR TITLE
Improve MercadoLibre login handling

### DIFF
--- a/src/components/routes/publicar/publicar.css
+++ b/src/components/routes/publicar/publicar.css
@@ -357,3 +357,20 @@ input[type=checkbox]{
 .meli-login-button:hover {
   background-color: #ffcc00;
 }
+
+.c-loader {
+  margin: 20% auto;
+  width: 100px;
+  height: 100px;
+  border: 3px solid #e5e5e5;
+  border-top-color: #a51a1a;
+  display: block;
+  animation: is-rotating 1s infinite;
+  border-radius: 50%;
+}
+
+@keyframes is-rotating {
+  to {
+    transform: rotate(1turn);
+  }
+}


### PR DESCRIPTION
## Summary
- add session check loader on publish page
- close MercadoLibre session on 403 errors
- hide ML login when session is active
- show toast on MercadoLibre fetch errors

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866a563c20883268a2483a318211704