### PR TITLE
Fix price input handler

### DIFF
--- a/src/components/routes/publicar/Publicar.js
+++ b/src/components/routes/publicar/Publicar.js
@@ -334,7 +334,7 @@ export const Publicar = () => {
                       dispatch({
                         type: "setPrice",
                         field: "value",
-                        value: e.value,
+                        value: e.target.value,
                       })
                     }
                   />

--- a/src/components/routes/publicar/reducer.test.js
+++ b/src/components/routes/publicar/reducer.test.js
@@ -1,0 +1,12 @@
+import { reducer } from './reducer';
+
+const initialState = { price: { value: '', currency: 'USD' } };
+
+test('setPrice action updates price value', () => {
+  const newState = reducer(initialState, {
+    type: 'setPrice',
+    field: 'value',
+    value: '1234',
+  });
+  expect(newState.price.value).toBe('1234');
+});


### PR DESCRIPTION
## Summary
- fix price `onChange` handler to use `e.target.value`
- add reducer test for updating price

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_686ea0008f948326be1fdefd417b604c