### PR TITLE
Ensure edit icon is black

### DIFF
--- a/src/components/card/card.css
+++ b/src/components/card/card.css
@@ -203,6 +203,8 @@
   padding: 4px;
   border-radius: 4px;
   cursor: pointer;
+  color: black;
+  text-decoration: none;
 }
 .hc-control-button:hover{
   background-color: #f0f0f0;
@@ -215,5 +217,4 @@
 abbr[title]{
   text-decoration: none;
   margin-right: 4px;
-  cursor: default;
-}
+  cursor: default;}


### PR DESCRIPTION
## Summary
- darken the color for `.hc-control-button`

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686e9ffe314c8326bae67d0d24caa295