### PR TITLE
Fix publishing form initialization

### DIFF
--- a/src/components/routes/publicar/Publicar.js
+++ b/src/components/routes/publicar/Publicar.js
@@ -43,7 +43,11 @@ export const Publicar = () => {
         .get()
         .then((doc) => {
           if (doc.exists) {
-            dispatch({ type: "setAll", value: doc.data() });
+            const data = { ...CF.initialState, ...doc.data() };
+            dispatch({ type: "setAll", value: data });
+            if (Array.isArray(data.images)) {
+              setFilesArrayRaw(data.images);
+            }
           }
         });
     }
@@ -334,7 +338,7 @@ export const Publicar = () => {
                       dispatch({
                         type: "setPrice",
                         field: "value",
-                        value: e.value,
+                        value: e.target.value,
                       })
                     }
                   />
@@ -488,6 +492,7 @@ export const Publicar = () => {
                 className="publish-form-video-input"
                 type="text"
                 placeholder="Enlace video YouTube..."
+                value={state.video_id || ""}
                 onChange={(e) =>
                   dispatch({ type: "field", field: "video_id", value: e.target.value.match(/(?<=watch\?v=)[\w-]+/) })
                 }
@@ -505,21 +510,21 @@ export const Publicar = () => {
             </div>
             <div>
               <input
-                value={state.featured}
+                checked={state.featured}
                 onChange={(e) => dispatch({ type: "field", field: "featured", value: e.target.checked })}
                 type="checkbox"
               />
               <label> Propiedad destacada </label>
               <br />
               <input
-                value={state.rentalFeatured}
+                checked={state.rentalFeatured}
                 onChange={(e) => dispatch({ type: "field", field: "rentalFeatured", value: e.target.checked })}
                 type="checkbox"
               />
               <label> Propiedad destacada en Alquiler Temporal </label>
               <br />
               <input
-                value={state.featured}
+                checked={state.slider}
                 onChange={(e) => dispatch({ type: "field", field: "slider", value: e.target.checked })}
                 name="terms"
                 type="checkbox"

--- a/src/components/routes/publicar/const_funct.js
+++ b/src/components/routes/publicar/const_funct.js
@@ -200,8 +200,13 @@ export const doImageListFromFiles = (files, remove) => {
     if (!file) {
       return null;
     }
+    const src =
+      typeof file === "string"
+        ? file
+        : (window.URL || window.webkitURL).createObjectURL(file);
+    const key = file.name || index;
     return (
-      <li className="publish-form-images-container" key={file.name}>
+      <li className="publish-form-images-container" key={key}>
         <button
           type="button"
           className="publish-form-delete-images"
@@ -211,7 +216,7 @@ export const doImageListFromFiles = (files, remove) => {
         </button>
         <img
           className="publish-form-images-images"
-          src={(window.URL || window.webkitURL).createObjectURL(file)}
+          src={src}
           alt="imagen no valida"
         />
       </li>


### PR DESCRIPTION
## Summary
- merge fetched document with default state when editing
- display video ID field value and bind price input correctly
- show existing images for editing
- use checkbox `checked` prop for flags

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm install --silent` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686e9ffc5ad8832692b65f38c822fcc2