### PR TITLE
Add comprehensive property type support

### DIFF
--- a/src/components/routes/alquiler-anual/AlquilerAnual.js
+++ b/src/components/routes/alquiler-anual/AlquilerAnual.js
@@ -6,6 +6,7 @@ import Card from "../../card/Card";
 import EmptyState from "../../emptyState/EmptyState";
 import "react-dropdown/style.css";
 import Dropdown from "react-dropdown";
+import { PROPERTY_TYPES } from "../../../constants/propertyTypes";
 
 const AlquilerAnual = () => {
   const [propieties, setPropieties] = useState([]);
@@ -34,7 +35,7 @@ const AlquilerAnual = () => {
           <p className="temporal-dropwdown-description">Tipo de propiedad</p>
           <Dropdown
             className="temporal-dropdown"
-            options={["Cualquiera", "Casa", "Departamento", "Local"]}
+            options={["Cualquiera", ...PROPERTY_TYPES]}
             value={filterSearch.type}
             onChange={(e) => setFilterSearch({ ...filterSearch, type: e.value })}
           />

--- a/src/components/routes/alquiler-temporal/AlquilerTemporal.js
+++ b/src/components/routes/alquiler-temporal/AlquilerTemporal.js
@@ -5,6 +5,7 @@ import "./alquiler-temporal.css";
 import Dropdown from "react-dropdown";
 import React, { useState, useEffect } from "react";
 import { firestore } from "../../../firebase";
+import { PROPERTY_TYPES } from "../../../constants/propertyTypes";
 import Card from "../../card/Card";
 import EmptyState from "../../emptyState/EmptyState";
 
@@ -36,7 +37,7 @@ const AlquilerTemporal = () => {
           <p className="temporal-dropwdown-description">Tipo de propiedad</p>
           <Dropdown
             className="temporal-dropdown"
-            options={["Cualquiera", "Casa", "Departamento"]}
+            options={["Cualquiera", ...PROPERTY_TYPES]}
             value={filterSearch.type}
             onChange={(e) => setFilterSearch({ ...filterSearch, type: e.value })}
           />

--- a/src/components/routes/dashboard/Dashboard.js
+++ b/src/components/routes/dashboard/Dashboard.js
@@ -8,6 +8,7 @@ import { useAuthState } from "react-firebase-hooks/auth";
 import { ToastContainer } from "react-toastify";
 import { Link } from "react-router-dom";
 import * as ROUTES from "../../../routes";
+import { PROPERTY_TYPES } from "../../../constants/propertyTypes";
 // import { useAuthState } from "react-firebase-hooks/auth";
 const Dashboard = () => {
   const [propieties, setPropieties] = useState([]);
@@ -20,9 +21,7 @@ const Dashboard = () => {
     venta: true,
     anual: true,
     temporal: true,
-    casa: true,
-    departamento: true,
-    lote: true,
+    types: PROPERTY_TYPES.reduce((acc, type) => ({ ...acc, [type]: true }), {}),
     featured: true,
     rentalFeatured: true,
     slider: true,
@@ -137,33 +136,22 @@ const Dashboard = () => {
           </div>
           <div className="db-aside-filter">
             <h2 className="db-aside-h2">Tipo de propiedad</h2>
-            <label htmlFor="casa" className="db-aside-label">
-              <input
-                type="checkbox"
-                name="casa"
-                checked={filter.casa}
-                onChange={(e) => setFilter((prev) => ({ ...prev, casa: e.target.checked }))}
-              />
-              Casa
-            </label>
-            <label htmlFor="departamento" className="db-aside-label">
-              <input
-                type="checkbox"
-                name="departamento"
-                checked={filter.departamento}
-                onChange={(e) => setFilter((prev) => ({ ...prev, departamento: e.target.checked }))}
-              />
-              Departamento
-            </label>
-            <label htmlFor="lote" className="db-aside-label">
-              <input
-                type="checkbox"
-                name="lote"
-                checked={filter.lote}
-                onChange={(e) => setFilter((prev) => ({ ...prev, lote: e.target.checked }))}
-              />
-              Terreno y lote
-            </label>
+            {PROPERTY_TYPES.map((type) => (
+              <label key={type} className="db-aside-label">
+                <input
+                  type="checkbox"
+                  name={type}
+                  checked={filter.types[type]}
+                  onChange={(e) =>
+                    setFilter((prev) => ({
+                      ...prev,
+                      types: { ...prev.types, [type]: e.target.checked },
+                    }))
+                  }
+                />
+                {type}
+              </label>
+            ))}
           </div>
           <div className="db-aside-filter">
             <h2 className="db-aside-h2">
@@ -236,13 +224,7 @@ const Dashboard = () => {
                 if (filter.anual && status === "Alquiler") return true;
                 return false;
               })
-              .filter((e) => {
-                const status = e.data().type;
-                if (filter.casa && status === "Casa") return true;
-                if (filter.departamento && status === "Departamento") return true;
-                if (filter.lote && status === "Terreno y lote") return true;
-                return false;
-              })
+              .filter((e) => filter.types[e.data().type])
               .filter((e) => {
                 const data = e.data();
                 if (filter.featured && data.featured) return true;

--- a/src/components/routes/home/Home.js
+++ b/src/components/routes/home/Home.js
@@ -13,6 +13,7 @@ import { firestore } from "../../../firebase";
 import "react-dropdown/style.css";
 import Dropdown from "react-dropdown";
 import { BUSQUEDA_GLOBAL } from "../../../routes";
+import { PROPERTY_TYPES } from "../../../constants/propertyTypes";
 
 const Home = () => {
   const [slider, setSlider] = useState([]);
@@ -87,7 +88,7 @@ const Home = () => {
           <p className="temporal-dropwdown-description">Tipo de propiedad</p>
           <Dropdown
             className="temporal-dropdown"
-            options={["Cualquiera", "Casa", "Departamento", "Terreno y lote"]}
+            options={["Cualquiera", ...PROPERTY_TYPES]}
             value={filterSearch.type}
             onChange={(e) => setFilterSearch({ ...filterSearch, type: e.value })}
           />

--- a/src/components/routes/publicar/const_funct.js
+++ b/src/components/routes/publicar/const_funct.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { storage } from "../../../firebase";
 import { compressImage } from "../../../utils/imageOptim";
+import { PROPERTY_TYPES } from "../../../constants/propertyTypes";
 
 export const attributes = [
   "Heladera",
@@ -101,7 +102,7 @@ export const initialState = {
 };
 
 export const dropdownVariables = {
-  type: ["Departamento", "Local comercial", "Casa", "Hotel", "Terreno y lote", "Otro inmueble"],
+  type: PROPERTY_TYPES,
   status: ["Alquiler temporal", "Alquiler anual", "Venta"],
   correncyOptions: ["USD", "ARS", "EUR"],
 };

--- a/src/components/routes/venta/Venta.js
+++ b/src/components/routes/venta/Venta.js
@@ -7,6 +7,7 @@ import Card from "../../card/Card";
 import EmptyState from "../../emptyState/EmptyState";
 import "react-dropdown/style.css";
 import Dropdown from "react-dropdown";
+import { PROPERTY_TYPES } from "../../../constants/propertyTypes";
 
 const Venta = () => {
   const [propieties, setPropieties] = useState([]);
@@ -37,7 +38,7 @@ const Venta = () => {
           <p className="temporal-dropwdown-description">Tipo de propiedad</p>
           <Dropdown
             className="temporal-dropdown"
-            options={["Cualquiera", "Casa", "Departamento", "Terreno y lote"]}
+            options={["Cualquiera", ...PROPERTY_TYPES]}
             value={filterSearch.type}
             onChange={(e) => setFilterSearch({ ...filterSearch, type: e.value })}
           />

--- a/src/constants/propertyTypes.js
+++ b/src/constants/propertyTypes.js
@@ -1,0 +1,17 @@
+export const PROPERTY_TYPES = [
+  "Departamento",
+  "Casa",
+  "Camas Náuticas",
+  "Campos",
+  "Cocheras",
+  "Consultorios",
+  "Depósitos y Galpones",
+  "Fondo de Comercio",
+  "Locales",
+  "Oficinas",
+  "Otros Inmuebles",
+  "PH",
+  "Parcelas, Nichos y Bóvedas",
+  "Terrenos y Lotes",
+  "Tiempo Compartido"
+];


### PR DESCRIPTION
## Summary
- centralize property types in a constant
- use PROPERTY_TYPES in publish flow
- extend search filters on Home, Alquiler Temporal/Anual and Venta pages
- update Dashboard filters to handle all property types

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687808f597a48326973869435f21110f