### PR TITLE
Fix rentalFeatured flag check

### DIFF
--- a/src/components/routes/home/Home.js
+++ b/src/components/routes/home/Home.js
@@ -49,7 +49,7 @@ const Home = () => {
           if (data.featured) {
             setFeatureds((ps) => [...ps, doc]);
           }
-          if (data.rentalfeatured) {
+          if (data.rentalFeatured) {
             setRentalFeatureds((ps) => [...ps, doc]);
           }
           setLocations((ps) => (ps.indexOf(data.location.city) === -1 ? [...ps, data.location.city] : ps));


### PR DESCRIPTION
## Summary
- correct the property flag casing when fetching rentals in `Home`

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68782a8ecbb88326a6d5bd1b8afb4216